### PR TITLE
Add option to dump minimal JSON

### DIFF
--- a/cvss/constants3.py
+++ b/cvss/constants3.py
@@ -17,6 +17,34 @@ except ImportError:
     from ordereddict import OrderedDict
 
 
+METRICS_ABBREVIATIONS_JSON = OrderedDict([('AV', 'attackVector'),
+                                     ('AC', 'attackComplexity'),
+                                     ('PR', 'privilegesRequired'),
+                                     ('UI', 'userInteraction'),
+                                     ('S', 'scope'),
+                                     ('C', 'confidentialityImpact'),
+                                     ('I', 'integrityImpact'),
+                                     ('A', 'availabilityImpact'),
+
+                                     ('E', 'exploitCodeMaturity'),
+                                     ('RL', 'remediationLevel'),
+                                     ('RC', 'reportConfidence'),
+                                     ('CR', 'confidentialityRequirement'),
+                                     ('IR', 'integrityRequirement'),
+                                     ('AR', 'availabilityRequirement'),
+                                     ('MAV', 'modifiedAttackVector'),
+                                     ('MAC', 'modifiedAttackComplexity'),
+                                     ('MPR', 'modifiedPrivilegesRequired'),
+                                     ('MUI', 'modifiedUserInteraction'),
+                                     ('MS', 'modifiedScope'),
+                                     ('MC', 'modifiedConfidentialityImpact'),
+                                     ('MI', 'modifiedIntegrityImpact'),
+                                     ('MA', 'modifiedAvailabilityImpact'),
+                                     ])
+
+TEMPORAL_METRICS = ['E', 'RL', 'RC']
+ENVIRONMENTAL_METRICS = ['CR','IR','AR','MAV', 'MAC', 'MPR', 'MUI', 'MC', 'MI', 'MA']
+
 METRICS_ABBREVIATIONS = OrderedDict([('AV', 'Attack Vector'),
                                      ('AC', 'Attack Complexity'),
                                      ('PR', 'Privileges Required'),

--- a/cvss/cvss3.py
+++ b/cvss/cvss3.py
@@ -14,8 +14,8 @@ from __future__ import unicode_literals
 import copy
 from decimal import Decimal as D, ROUND_CEILING
 
-from .constants3 import METRICS_ABBREVIATIONS, METRICS_MANDATORY, METRICS_VALUES, \
-    METRICS_VALUE_NAMES, OrderedDict
+from .constants3 import METRICS_ABBREVIATIONS, METRICS_ABBREVIATIONS_JSON, METRICS_MANDATORY, METRICS_VALUES, \
+    METRICS_VALUE_NAMES, OrderedDict, ENVIRONMENTAL_METRICS, TEMPORAL_METRICS
 from .exceptions import CVSS3MalformedError, CVSS3MandatoryError, CVSS3RHMalformedError, \
     CVSS3RHScoreDoesNotMatch
 
@@ -196,6 +196,20 @@ class CVSS3(object):
             result = METRICS_VALUES[abbreviation][string_value]
         return result
 
+    def is_environmental_used(self):
+        is_used = False
+        for metric in ENVIRONMENTAL_METRICS:
+            if metric in self.original_metrics:
+                is_used = True
+        return is_used
+
+    def is_temporal_used(self):
+        is_used = False
+        for metric in TEMPORAL_METRICS:
+            if metric in self.original_metrics:
+                is_used = True
+        return is_used
+        
     def get_value_description(self, abbreviation):
         """
         Gets textual description of specific metric specified by its abbreviation.
@@ -409,7 +423,7 @@ class CVSS3(object):
     def __hash__(self):
         return hash(self.clean_vector())
 
-    def as_json(self, sort=False):
+    def as_json(self, sort=False, minimal=False):
         """
         Returns a dictionary formatted with attribute names and values defined by the official
         CVSS JSON schema:
@@ -437,43 +451,32 @@ class CVSS3(object):
             return text.upper().replace('-', '_').replace(' ', '_')
 
         base_severity, temporal_severity, environmental_severity = self.severities()
-        data = {
-            # Meta
-            'version': '3.' + str(self.minor_version),
-            # Vector
-            'vectorString': self.vector,
-            # Metrics
-            'attackVector': us(self.get_value_description('AV')),
-            'attackComplexity': us(self.get_value_description('AC')),
-            'privilegesRequired': us(self.get_value_description('PR')),
-            'userInteraction': us(self.get_value_description('UI')),
-            'scope': us(self.get_value_description('S')),
-            'confidentialityImpact': us(self.get_value_description('C')),
-            'integrityImpact': us(self.get_value_description('I')),
-            'availabilityImpact': us(self.get_value_description('A')),
-            'exploitCodeMaturity': us(self.get_value_description('E')),
-            'remediationLevel': us(self.get_value_description('RL')),
-            'reportConfidence': us(self.get_value_description('RC')),
-            'confidentialityRequirement': us(self.get_value_description('CR')),
-            'integrityRequirement': us(self.get_value_description('IR')),
-            'availabilityRequirement': us(self.get_value_description('AR')),
-            'modifiedAttackVector': us(self.get_value_description('MAV')),
-            'modifiedAttackComplexity': us(self.get_value_description('MAC')),
-            'modifiedPrivilegesRequired': us(self.get_value_description('MPR')),
-            'modifiedUserInteraction': us(self.get_value_description('MUI')),
-            'modifiedScope': us(self.get_value_description('MS')),
-            'modifiedConfidentialityImpact': us(self.get_value_description('MC')),
-            'modifiedIntegrityImpact': us(self.get_value_description('MI')),
-            'modifiedAvailabilityImpact': us(self.get_value_description('MA')),
-            # Scores
-            'baseScore': float(self.base_score),
-            'environmentalScore': float(self.environmental_score),
-            'temporalScore': float(self.temporal_score),
-            # Severities
-            'baseSeverity': us(base_severity),
-            'environmentalSeverity': us(environmental_severity),
-            'temporalSeverity': us(temporal_severity),
-        }
+
+        data = {}
+        data['vector'] = self.vector
+        data['version'] = '3.' + str(self.minor_version)
+        data['baseScore'] =  float(self.base_score)
+
+        def add_metric_to_data(metric):
+            k = METRICS_ABBREVIATIONS_JSON[metric]
+            data[k] = us(self.get_value_description(metric))
+        
+        # add Base Metrics to JSON
+        for metric in METRICS_MANDATORY:
+            add_metric_to_data(metric)
+        data['baseSeverity'] = us(base_severity)
+
+        if self.is_temporal_used() or not minimal:
+            for metric in TEMPORAL_METRICS:
+                add_metric_to_data(metric)
+            data['temporalScore'] = float(self.temporal_score)
+            data['temporalSeverity'] = us(temporal_severity)
+
+        if self.is_environmental_used() or not minimal:
+            for metric in ENVIRONMENTAL_METRICS:
+                add_metric_to_data(metric)
+            data['environmentalScore'] = float(self.environmental_score)
+            data['environmentalSeverity'] = us(environmental_severity)                
 
         if sort:
             data = OrderedDict(sorted(data.items()))

--- a/tests/test_cvss3.py
+++ b/tests/test_cvss3.py
@@ -362,6 +362,33 @@ class TestCVSS3(unittest.TestCase):
         self.assertEqual(json['temporalSeverity'], "MEDIUM")
         self.assertEqual(json['environmentalSeverity'], "LOW")
 
+    def test_json_schema_minimal_base_only(self):
+        v = 'CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L'
+        json = CVSS3(v).as_json(minimal=True)
+        # selectively test some values
+        self.assertEqual(json['baseSeverity'], "HIGH")
+        self.assertIn('attackVector', json)
+        self.assertNotIn('exploitCodeMaturity', json)
+        self.assertNotIn('modifiedAttackVector', json)
+
+    def test_json_schema_minimal_temporal_only(self):
+        v = 'CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L/E:H'
+        json = CVSS3(v).as_json(minimal=True)
+        # selectively test some values
+        self.assertEqual(json['baseSeverity'], "HIGH")
+        self.assertIn('attackVector', json)
+        self.assertIn('exploitCodeMaturity', json)
+        self.assertIn('temporalSeverity', json)
+        self.assertNotIn('modifiedAttackVector', json)
+
+    def test_json_schema_minimal_environmental_only(self):
+        v = 'CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L/CR:H'
+        json = CVSS3(v).as_json(minimal=True)
+        # selectively test some values
+        self.assertEqual(json['baseSeverity'], "HIGH")
+        self.assertIn('attackVector', json)
+        self.assertNotIn('exploitCodeMaturity', json)
+        self.assertIn('confidentialityRequirement', json)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Hi, 

currently CVSS3.as_json() adds metrics to the JSON representation of the vector, which were not part of the user-supplied vector. For example, if no "Modified Attack Vector" is supplied in the vector, the JSON will contain the MAV property with the value from AV.

This PR adds the parameter "minimal=True" to "CVSS3.as_json", which allows to dump only a minimal JSON.