### PR TITLE
Add standardized test execution through Tox

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,19 +7,15 @@ on:
   pull_request:
 
 jobs:
-  test:
-    name: Run tests
-    runs-on: ubuntu-latest
-
+  tox:
+    name: Run Tox
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }} testing env
-      uses: actions/setup-python@v2
+    - name: Run all envs
+      uses: fedora-python/tox-github-action@master
       with:
-        python-version: ${{ matrix.python-version }}
-    - name: Test
-      run: pip install jsonschema && cd tests && bash run_tests.sh
-
+        tox_env: ${{ matrix.tox_env }}
     strategy:
       matrix:
-        python-version: [2.7, 3.6, 3.7, 3.8, 3.9]
+        tox_env: [py27, py36, py37, py38, py39, py310, py311]
+    runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__
 build
 dist
 .idea
+.tox

--- a/README.rst
+++ b/README.rst
@@ -75,9 +75,9 @@ Testing
 For extensive testing, the test vectors were generated using official
 JavaScript generators and `cvsslib <https://github.com/ctxis/cvsslib>`_.
 
-To run all tests use the following script on a system with both Python 2 and Python 3 installed:
+To run all tests using all supported versions of Python 2 and Python 3 installed:
 
 ::
 
-    $ cd tests
-    $ bash run_tests.sh
+    $ tox
+    $ tox -e py311   # Run tests using a specific version of Python

--- a/setup.py
+++ b/setup.py
@@ -16,12 +16,27 @@ here = path.abspath(path.dirname(__file__))
 with codecs.open(path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
+with open("cvss/__init__.py") as f:
+    for line in f:
+        if line.startswith("__version__"):
+            delim = '"' if '"' in line else "'"
+            version = line.split(delim)[1]
+            break
+    else:
+        raise RuntimeError("Unable to find version string.")
+
 setup(
     name='cvss',
-    version='2.5',
+    version=version,
     description='CVSS2/3 library with interactive calculator for Python 2 and Python 3',
     long_description=long_description,
-    url='https://github.com/skontar/cvss',
+    url='https://github.com/RedHatProductSecurity/cvss',
+    project_urls={
+        "Releases": "https://github.com/RedHatProductSecurity/cvss/releases",
+        "Source code": "https://github.com/RedHatProductSecurity/cvss",
+        "Issues": "https://github.com/RedHatProductSecurity/cvss/issues",
+        "CI": "https://github.com/RedHatProductSecurity/cvss/actions",
+    },
     author='Stanislav Kontar, Red Hat Product Security',
     author_email='skontar@redhat.com',
     license='LGPLv3+',
@@ -31,16 +46,14 @@ setup(
         'Topic :: Security',
         'License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.2',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
     ],
     keywords='security cvss score calculator',
     packages=find_packages(),

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,7 +1,0 @@
-#!/bin/bash -x
-
-python3 test_cvss2.py
-python3 test_cvss3.py
-
-python2 test_cvss2.py
-python2 test_cvss3.py

--- a/tests/test_cvss2.py
+++ b/tests/test_cvss2.py
@@ -261,12 +261,12 @@ class TestCVSS2(unittest.TestCase):
             import jsonschema
         except ImportError:
             return
+        with open(path.join(WD, 'schemas/cvss-v2.0.json')) as schema_file:
+            schema = json.load(schema_file)
         with open(path.join(WD, 'vectors_random2')) as f:
             for line in f:
                 vector, _ = line.split(' - ')
                 cvss = CVSS2(vector)
-                with open(path.join(WD, 'schemas/cvss-v2.0.json')) as schema_file:
-                    schema = json.load(schema_file)
                 try:
                     jsonschema.validate(instance=cvss.as_json(), schema=schema)
                 except jsonschema.exceptions.ValidationError:

--- a/tests/test_cvss3.py
+++ b/tests/test_cvss3.py
@@ -343,12 +343,12 @@ class TestCVSS3(unittest.TestCase):
             'vectors_random31': 'schemas/cvss-v3.1.json',
         }
         for vectors_file_path, schema_file_path in vectors_to_schema.items():
+            with open(path.join(WD, schema_file_path)) as schema_file:
+                schema = json.load(schema_file)
             with open(path.join(WD, vectors_file_path)) as f:
                 for line in f:
                     vector, _ = line.split(' - ')
                     cvss = CVSS3(vector)
-                    with open(path.join(WD, schema_file_path)) as schema_file:
-                        schema = json.load(schema_file)
                     try:
                         jsonschema.validate(instance=cvss.as_json(), schema=schema)
                     except jsonschema.exceptions.ValidationError:

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,8 @@
+[tox]
+envlist = py{27,36,37,38,39,310,311}
+
+[testenv]
+deps = jsonschema
+commands =
+    python tests/test_cvss2.py
+    python tests/test_cvss3.py


### PR DESCRIPTION
Use Tox to run tests against all Python versions.

This makes it easier to run tests against a specific version of Python (assuming it is available on the system), and allows for future addition of linting stages.
 
Also, rework the CI file to use the Tox GitHub action for parallel execution of all Tox stages. The previous CI would call Python 2 and 3 via a Bash script, which was problematic if the env did not have both versions installed, e.g.: https://github.com/RedHatProductSecurity/cvss/actions/runs/3953645813/jobs/6780884270