### PR TITLE
Add Modified Scope in Environmental Metrics (and JSON generation)

### DIFF
--- a/cvss/constants3.py
+++ b/cvss/constants3.py
@@ -74,7 +74,7 @@ METRICS_ABBREVIATIONS_JSON = OrderedDict(
 
 METRICS_MANDATORY = ["AV", "AC", "PR", "UI", "S", "C", "I", "A"]
 TEMPORAL_METRICS = ["E", "RL", "RC"]
-ENVIRONMENTAL_METRICS = ["CR", "IR", "AR", "MAV", "MAC", "MPR", "MUI", "MC", "MI", "MA"]
+ENVIRONMENTAL_METRICS = ["CR", "IR", "AR", "MAV", "MAC", "MPR", "MUI", "MS", "MC", "MI", "MA"]
 
 METRICS_VALUES = {
     "AV": {"N": D("0.85"), "A": D("0.62"), "L": D("0.55"), "P": D("0.2")},

--- a/cvss/cvss3.py
+++ b/cvss/cvss3.py
@@ -201,7 +201,7 @@ class CVSS3(object):
         also stored, as they may be used for printing back the minimal vector.
         """
         self.original_metrics = copy.copy(self.metrics)
-        for abbreviation in ["MAV", "MAC", "MPR", "MUI", "MC", "MI", "MA"]:
+        for abbreviation in ["MAV", "MAC", "MPR", "MUI", "MC", "MS", "MI", "MA"]:
             if abbreviation not in self.metrics or self.metrics[abbreviation] == "X":
                 self.metrics[abbreviation] = self.metrics[abbreviation[1:]]
 


### PR DESCRIPTION
Hello,

I noticed `modifiedScope` was missing from JSON generation, this patch fixed it for me. Please let me know if you think something else is missing!

Thanks!