### PR TITLE
Add option to view JSON of a CVSS vector

### DIFF
--- a/cvss/cvss_calculator.py
+++ b/cvss/cvss_calculator.py
@@ -10,6 +10,7 @@ mandatory metrics and computes CVSS3.1.
 from __future__ import print_function
 
 import argparse
+import json
 
 from cvss import CVSSError, ask_interactively
 
@@ -25,6 +26,9 @@ def main():
         parser.add_argument("-v", "--vector", help="input string with CVSS vector")
         parser.add_argument(
             "-n", "--no-colors", action="store_true", help="do not use terminal coloring"
+        )
+        parser.add_argument(
+            "-j", "--json", action="store_true", help="output vector in JSON format"
         )
         args = parser.parse_args()
 
@@ -70,6 +74,9 @@ def main():
                     print(scores[i])
             print("Cleaned vector:       ", cvss_vector.clean_vector())
             print("Red Hat vector:       ", cvss_vector.rh_vector())
+            if args.json:
+                json_output = json.dumps(cvss_vector.as_json(sort=True, minimal=True), indent=2)
+                print("CVSS vector in JSON:", json_output, sep="\n")
     except (KeyboardInterrupt, EOFError):
         print()
 

--- a/cvss/interactive.py
+++ b/cvss/interactive.py
@@ -102,7 +102,7 @@ def ask_interactively(version=3.1, all_metrics=False, no_colors=False):
         while True:
             print(METRICS_ABBREVIATIONS[metric] + ":", end=" ")
             print("/".join(values), end=" ")
-            input_value = string_input().upper()
+            input_value = string_input().strip().upper()
             if not input_value:
                 if version == 2:
                     input_value = "ND"


### PR DESCRIPTION
```
$ cvss_calculator -v CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:L/A:H -j
CVSS3
Base Score:            10.0 (Critical)
Temporal Score:        10.0 (Critical)
Environmental Score:   10.0 (Critical)
Cleaned vector:        CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:L/A:H
Red Hat vector:        10.0/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:L/A:H
CVSS vector in JSON:
{
  "attackComplexity": "LOW",
  "attackVector": "NETWORK",
  "availabilityImpact": "HIGH",
  "baseScore": 10.0,
  "baseSeverity": "CRITICAL",
  "confidentialityImpact": "HIGH",
  "integrityImpact": "LOW",
  "privilegesRequired": "NONE",
  "scope": "CHANGED",
  "userInteraction": "NONE",
  "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:L/A:H",
  "version": "3.1"
}
```