### PR TITLE
CVSSv4, fixes to unexpected severity results

### DIFF
--- a/cvss/cvss4.py
+++ b/cvss/cvss4.py
@@ -80,7 +80,7 @@ class CVSS4(object):
         self.missing_metrics = []
 
         self.base_score = None
-        self.base_severity = None
+        self.severity = None
 
         self.parse_vector()
         self.check_mandatory()
@@ -597,13 +597,13 @@ class CVSS4(object):
         Returns:
             (str): Severity string
         """
-        if self.base_score == D("0.0"):
+        if self.base_score == 0.0:
             self.severity = "None"
-        elif self.base_score <= D("3.9"):
+        elif self.base_score <= 3.9:
             self.severity = "Low"
-        elif self.base_score <= D("6.9"):
+        elif self.base_score <= 6.9:
             self.severity = "Medium"
-        elif self.base_score <= D("8.9"):
+        elif self.base_score <= 8.9:
             self.severity = "High"
         else:
             self.severity = "Critical"
@@ -647,7 +647,7 @@ class CVSS4(object):
         for metric in METRICS:
             add_metric_to_data(metric)
         data["baseScore"] = float(self.base_score)
-        data["baseSeverity"] = self.base_severity
+        data["baseSeverity"] = self.severity
 
         if sort:
             data = OrderedDict(sorted(data.items()))

--- a/tests/test_cvss4.py
+++ b/tests/test_cvss4.py
@@ -20,6 +20,10 @@ class TestCVSS4(unittest.TestCase):
                 result = CVSS4(vector)
                 results_score = result.base_score
                 self.assertEqual(expected_score, results_score, test_name + " - " + vector)
+                results_json_score = result.as_json()["baseScore"]
+                self.assertEqual(
+                    expected_score, results_json_score, test_name + " - " + vector + " - JSON"
+                )
 
     def test_base(self):
         """
@@ -68,6 +72,7 @@ class TestCVSS4(unittest.TestCase):
             "MPR:L/MUI:A/MVC:L/MVI:N/MVA:H/MSC:H/MSI:L/MSA:N/CR:H/IR:L/AR:L/E:P"
         )
         self.assertEqual(("Low"), CVSS4(v).severity, v)
+        self.assertEqual(("Low"), CVSS4(v).as_json()["baseSeverity"], v)
 
         v = (
             "CVSS:4.0/AV:L/AC:L/AT:P/PR:L/UI:P/VC:N/VI:L/VA:L/"
@@ -75,6 +80,7 @@ class TestCVSS4(unittest.TestCase):
             "/MPR:N/MUI:P/MVC:L/MVI:N/MVA:H/MSC:H/MSI:H/MSA:S/CR:M/IR:M/AR:M/E:A"
         )
         self.assertEqual(("High"), CVSS4(v).severity, v)
+        self.assertEqual(("High"), CVSS4(v).as_json()["baseSeverity"], v)
 
         v = (
             "CVSS:4.0/AV:N/AC:H/AT:P/PR:H/UI:A/VC:L/VI:N/VA:N/"
@@ -82,6 +88,7 @@ class TestCVSS4(unittest.TestCase):
             "/MPR:H/MUI:P/MVC:L/MVI:H/MVA:L/MSC:N/MSI:H/MSA:H/CR:L/IR:H/AR:M/E:U"
         )
         self.assertEqual(("Low"), CVSS4(v).severity, v)
+        self.assertEqual(("Low"), CVSS4(v).as_json()["baseSeverity"], v)
 
         v = (
             "CVSS:4.0/AV:A/AC:H/AT:N/PR:N/UI:A/VC:L/VI:L/VA:N/"
@@ -89,6 +96,7 @@ class TestCVSS4(unittest.TestCase):
             "/MPR:N/MUI:P/MVC:N/MVI:L/MVA:L/MSC:H/MSI:N/MSA:L/CR:M/IR:M/AR:L/E:U"
         )
         self.assertEqual(("Low"), CVSS4(v).severity, v)
+        self.assertEqual(("Low"), CVSS4(v).as_json()["baseSeverity"], v)
 
         v = (
             "CVSS:4.0/AV:L/AC:L/AT:P/PR:L/UI:A/VC:H/VI:H/VA:N/"
@@ -96,6 +104,7 @@ class TestCVSS4(unittest.TestCase):
             "/MPR:H/MUI:P/MVC:L/MVI:L/MVA:N/MSC:H/MSI:H/MSA:S/CR:H/IR:H/AR:H/E:P"
         )
         self.assertEqual(("Medium"), CVSS4(v).severity, v)
+        self.assertEqual(("Medium"), CVSS4(v).as_json()["baseSeverity"], v)
 
         v = (
             "CVSS:4.0/AV:N/AC:L/AT:N/PR:H/UI:N/VC:L/VI:L/VA:H/"
@@ -103,6 +112,11 @@ class TestCVSS4(unittest.TestCase):
             "/MPR:H/MUI:N/MVC:N/MVI:L/MVA:N/MSC:L/MSI:S/MSA:H/CR:H/IR:M/AR:M/E:A"
         )
         self.assertEqual(("Medium"), CVSS4(v).severity, v)
+        self.assertEqual(("Medium"), CVSS4(v).as_json()["baseSeverity"], v)
+
+        v = "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:L/VI:L/VA:L/SC:L/SI:L/SA:L"
+        self.assertEqual(("Medium"), CVSS4(v).severity, v)
+        self.assertEqual(("Medium"), CVSS4(v).as_json()["baseSeverity"], v)
 
         v = (
             "CVSS:4.0/AV:A/AC:H/AT:P/PR:N/UI:P/VC:N/VI:L/VA:N/"
@@ -110,6 +124,7 @@ class TestCVSS4(unittest.TestCase):
             "/MPR:L/MUI:A/MVC:N/MVI:L/MVA:H/MSC:L/MSI:N/MSA:S/CR:L/IR:L/AR:M/E:P"
         )
         self.assertEqual(("Low"), CVSS4(v).severity, v)
+        self.assertEqual(("Low"), CVSS4(v).as_json()["baseSeverity"], v)
 
         v = (
             "CVSS:4.0/AV:A/AC:H/AT:N/PR:H/UI:A/VC:H/VI:N/VA:H/"
@@ -117,6 +132,7 @@ class TestCVSS4(unittest.TestCase):
             "/MPR:N/MUI:N/MVC:H/MVI:H/MVA:H/MSC:H/MSI:S/MSA:S/CR:H/IR:H/AR:H/E:U"
         )
         self.assertEqual(("Critical"), CVSS4(v).severity, v)
+        self.assertEqual(("Critical"), CVSS4(v).as_json()["baseSeverity"], v)
 
         v = (
             "CVSS:4.0/AV:N/AC:H/AT:N/PR:H/UI:P/VC:L/VI:N/VA:H/"
@@ -124,6 +140,7 @@ class TestCVSS4(unittest.TestCase):
             "/MPR:N/MUI:A/MVC:L/MVI:H/MVA:H/MSC:N/MSI:H/MSA:L/CR:L/IR:H/AR:L/E:U"
         )
         self.assertEqual(("Medium"), CVSS4(v).severity, v)
+        self.assertEqual(("Medium"), CVSS4(v).as_json()["baseSeverity"], v)
 
         v = (
             "CVSS:4.0/AV:L/AC:H/AT:N/PR:N/UI:N/VC:L/VI:N/VA:H/"
@@ -131,6 +148,7 @@ class TestCVSS4(unittest.TestCase):
             "/MPR:L/MUI:P/MVC:N/MVI:N/MVA:N/MSC:N/MSI:N/MSA:N/CR:H/IR:H/AR:H/E:P"
         )
         self.assertEqual(("None"), CVSS4(v).severity, v)
+        self.assertEqual(("None"), CVSS4(v).as_json()["baseSeverity"], v)
 
     def test_json_schema_no_impact_metrics(self):
         v = "CVSS:4.0/AV:A/AC:H/AT:P/PR:L/UI:P/VC:N/VI:N/VA:N/SC:N/SI:N/SA:N"


### PR DESCRIPTION
- falcochu noticed that the json 'baseSeverity' was not returning a result and the severity for a score of 6.9 was incorrect
- The severity calculation was evaluating float(6.9) > D("6.9"), it now evaluates float(6.9) <= float(6.9) correctly
- json 'baseSeverity' now correctly returns the object's severity
- Added a severity test for CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:L/VI:L/VA:L/SC:L/SI:L/SA:L
- Added as_json test evaluation to run_tests_from_file
- Added as_json tests to test_severity