### PR TITLE
Update setup files

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal = 1

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
     version=version,
     description="CVSS2/3/4 library with interactive calculator for Python 2 and Python 3",
     long_description=long_description,
+    long_description_content_type="text/x-rst",
     url="https://github.com/RedHatProductSecurity/cvss",
     project_urls={
         "Releases": "https://github.com/RedHatProductSecurity/cvss/releases",

--- a/setup.py
+++ b/setup.py
@@ -64,4 +64,6 @@ setup(
             "cvss_calculator = cvss.cvss_calculator:main",
         ],
     },
+    # to make Python 2 and Python 3 compatible wheel
+    options={"bdist_wheel": {"universal": "1"}},
 )


### PR DESCRIPTION
This PR adds `long_description_content_type` to `setup()` in `setup.py` to avoid a warning when running `twine`.
It also moves `bdist_wheel` from `setup.cfg` to `setup.py`,  as this option was the only one in the file.