### PR TITLE
fix(CVSS2, CVSS3, CVSS4): implement and correct __eq__ methods

### DIFF
--- a/cvss/cvss2.py
+++ b/cvss/cvss2.py
@@ -321,14 +321,6 @@ class CVSS2(object):
         """
         return str(self.scores()[0]) + "/" + self.clean_vector()
 
-    def __eq__(self, o):
-        if isinstance(o, CVSS2):
-            return self.clean_vector().__eq__(o.clean_vector())
-        return NotImplemented
-
-    def __hash__(self):
-        return hash(self.clean_vector())
-
     def as_json(self, sort=False, minimal=False):
         """
         Returns a dictionary formatted with attribute names and values defined by the official
@@ -381,3 +373,11 @@ class CVSS2(object):
             data = OrderedDict(sorted(data.items()))
 
         return data
+
+    def __hash__(self) -> int:
+        return hash(self.clean_vector())
+
+    def __eq__(self, o) -> bool:
+        if isinstance(o, CVSS2):
+            return self.clean_vector() == o.clean_vector()
+        return False

--- a/cvss/cvss2.py
+++ b/cvss/cvss2.py
@@ -374,10 +374,10 @@ class CVSS2(object):
 
         return data
 
-    def __hash__(self) -> int:
+    def __hash__(self):
         return hash(self.clean_vector())
 
-    def __eq__(self, o) -> bool:
+    def __eq__(self, o):
         if isinstance(o, CVSS2):
             return self.clean_vector() == o.clean_vector()
         return False

--- a/cvss/cvss3.py
+++ b/cvss/cvss3.py
@@ -501,10 +501,10 @@ class CVSS3(object):
             data = OrderedDict(sorted(data.items()))
         return data
 
-    def __hash__(self) -> int:
+    def __hash__(self):
         return hash(self.clean_vector())
 
-    def __eq__(self, o) -> bool:
+    def __eq__(self, o):
         if isinstance(o, CVSS3):
             return self.clean_vector() == o.clean_vector()
         return False

--- a/cvss/cvss3.py
+++ b/cvss/cvss3.py
@@ -441,14 +441,6 @@ class CVSS3(object):
         """
         return str(self.scores()[0]) + "/" + self.clean_vector()
 
-    def __eq__(self, o):
-        if isinstance(o, CVSS3):
-            return self.clean_vector().__eq__(o.clean_vector())
-        return NotImplemented
-
-    def __hash__(self):
-        return hash(self.clean_vector())
-
     def as_json(self, sort=False, minimal=False):
         """
         Returns a dictionary formatted with attribute names and values defined by the official
@@ -508,3 +500,11 @@ class CVSS3(object):
         if sort:
             data = OrderedDict(sorted(data.items()))
         return data
+
+    def __hash__(self) -> int:
+        return hash(self.clean_vector())
+
+    def __eq__(self, o) -> bool:
+        if isinstance(o, CVSS3):
+            return self.clean_vector() == o.clean_vector()
+        return False

--- a/cvss/cvss4.py
+++ b/cvss/cvss4.py
@@ -668,10 +668,10 @@ class CVSS4(object):
             data = OrderedDict(sorted(data.items()))
         return data
 
-    def __hash__(self) -> int:
+    def __hash__(self):
         return hash(self.clean_vector())
 
-    def __eq__(self, o) -> bool:
+    def __eq__(self, o):
         if isinstance(o, CVSS4):
             return self.clean_vector() == o.clean_vector()
         return False

--- a/cvss/cvss4.py
+++ b/cvss/cvss4.py
@@ -549,9 +549,6 @@ class CVSS4(object):
 
         self.base_score = round_away_from_zero(value)
 
-    def __hash__(self):
-        return hash(self.clean_vector())
-
     def clean_vector(self, output_prefix=True):
         """
         Returns vector without optional metrics marked as X and in preferred order.
@@ -670,3 +667,11 @@ class CVSS4(object):
         if sort:
             data = OrderedDict(sorted(data.items()))
         return data
+
+    def __hash__(self) -> int:
+        return hash(self.clean_vector())
+
+    def __eq__(self, o) -> bool:
+        if isinstance(o, CVSS4):
+            return self.clean_vector() == o.clean_vector()
+        return False


### PR DESCRIPTION
This PR addresses the following:

- Implement the missing `__eq__` method in the `CVSS4` class, which was necessary to enable proper object comparison. Without this, comparing two `CVSS4` objects would not work correctly.
- Correct and refactor the `__eq__` methods in `CVSS2` and `CVSS3` to ensure consistency across all CVSS classes.

These changes resolve issues with object comparisons and ensure that all CVSS classes now follow consistent behavior when comparing instances.