### PR TITLE
feat(CVSS2, CVSS3): add methods to fetch isolated temporal and environmental vectors

### DIFF
--- a/cvss/cvss2.py
+++ b/cvss/cvss2.py
@@ -321,6 +321,28 @@ class CVSS2(object):
         """
         return str(self.scores()[0]) + "/" + self.clean_vector()
 
+    def temporal_vector(self):
+        """
+        Returns the temporal vector from the full CVSS vector.
+
+        Returns:
+            (str): Temporal CVSS vector.
+        """
+        return "/".join(
+            [metric + ":" + self.metrics.get(metric, "ND") for metric in TEMPORAL_METRICS]
+        )
+
+    def environmental_vector(self):
+        """
+        Returns the environmental vector from the full CVSS vector.
+
+        Returns:
+            (str): Environmental CVSS vector.
+        """
+        return "/".join(
+            [metric + ":" + self.metrics.get(metric, "ND") for metric in ENVIRONMENTAL_METRICS]
+        )
+
     def as_json(self, sort=False, minimal=False):
         """
         Returns a dictionary formatted with attribute names and values defined by the official

--- a/cvss/cvss3.py
+++ b/cvss/cvss3.py
@@ -441,6 +441,28 @@ class CVSS3(object):
         """
         return str(self.scores()[0]) + "/" + self.clean_vector()
 
+    def temporal_vector(self):
+        """
+        Returns the temporal vector from the full CVSS vector.
+
+        Returns:
+            (str): Temporal CVSS vector.
+        """
+        return "/".join(
+            [metric + ":" + self.metrics.get(metric, "X") for metric in TEMPORAL_METRICS]
+        )
+
+    def environmental_vector(self):
+        """
+        Returns the environmental vector from the full CVSS vector.
+
+        Returns:
+            (str): Environmental CVSS vector.
+        """
+        return "/".join(
+            [metric + ":" + self.metrics.get(metric, "X") for metric in ENVIRONMENTAL_METRICS]
+        )
+
     def as_json(self, sort=False, minimal=False):
         """
         Returns a dictionary formatted with attribute names and values defined by the official

--- a/tests/test_cvss2.py
+++ b/tests/test_cvss2.py
@@ -190,6 +190,62 @@ class TestCVSS2(unittest.TestCase):
         v = "ABC/AV:L/AC:H/Au:M/C:C/I:P/A:P"
         self.assertRaises(CVSS2RHMalformedError, CVSS2.from_rh_vector, v)
 
+    def test_temporal_vector(self):
+        """
+        Test for retrieving only the Temporal CVSS Vector.
+        """
+        v = "AV:A/AC:H/Au:S/C:C/I:C/A:P/E:U/RL:U/RC:UR/CDP:ND/TD:ND/CR:L/IR:M/AR:ND"
+        self.assertEqual(
+            "E:U/RL:U/RC:UR",
+            CVSS2(v).temporal_vector(),
+        )
+
+        v = "AV:A/AC:H/Au:S/C:C/I:C/A:P/CDP:ND/TD:ND/CR:L/IR:M/AR:ND"
+        self.assertEqual(
+            "E:ND/RL:ND/RC:ND",
+            CVSS2(v).temporal_vector(),
+        )
+
+        v = "AV:A/AC:H/Au:S/C:C/I:C/A:P/RL:U/RC:UR/CDP:ND/TD:ND/CR:L/IR:M/AR:ND"
+        self.assertEqual(
+            "E:ND/RL:U/RC:UR",
+            CVSS2(v).temporal_vector(),
+        )
+
+        v = "AV:A/AC:H/Au:S/C:C/I:C/A:P/E:U/RC:UR/CDP:ND/TD:ND/CR:L/IR:M/AR:ND"
+        self.assertEqual(
+            "E:U/RL:ND/RC:UR",
+            CVSS2(v).temporal_vector(),
+        )
+
+        v = "AV:A/AC:H/Au:S/C:C/I:C/A:P/E:U/RL:U/CDP:ND/TD:ND/CR:L/IR:M/AR:ND"
+        self.assertEqual(
+            "E:U/RL:U/RC:ND",
+            CVSS2(v).temporal_vector(),
+        )
+
+    def test_environmental_vector(self):
+        """
+        Test for retrieving only the Environmental CVSS Vector.
+        """
+        v = "AV:A/AC:H/Au:S/C:C/I:C/A:P/E:U/RL:U/CDP:N/TD:N/CR:L/IR:M/AR:L"
+        self.assertEqual(
+            "CDP:N/TD:N/CR:L/IR:M/AR:L",
+            CVSS2(v).environmental_vector(),
+        )
+
+        v = "AV:A/AC:H/Au:S/C:C/I:C/A:P/E:U/RL:U"
+        self.assertEqual(
+            "CDP:ND/TD:ND/CR:ND/IR:ND/AR:ND",
+            CVSS2(v).environmental_vector(),
+        )
+
+        v = "AV:A/AC:H/Au:S/C:C/I:C/A:P/E:U/RL:U/TD:N/CR:L/IR:M/AR:L"
+        self.assertEqual(
+            "CDP:ND/TD:N/CR:L/IR:M/AR:L",
+            CVSS2(v).environmental_vector(),
+        )
+
     def test_parse_from_text_cvss2(self):
         """
         Tests for parsing CVSS from text.

--- a/tests/test_cvss3.py
+++ b/tests/test_cvss3.py
@@ -230,6 +230,83 @@ class TestCVSS3(unittest.TestCase):
         v = "ABC/CVSS:3.0/AV:A/AC:H/PR:N/UI:R/S:C/C:L/I:H/A:L"
         self.assertRaises(CVSS3RHMalformedError, CVSS3.from_rh_vector, v)
 
+    def test_temporal_vector(self):
+        """
+        Test for retrieving only the Temporal CVSS Vector.
+        """
+        v = (
+            "CVSS:3.0/S:C/C:H/I:H/A:N/AV:P/AC:H/PR:H/UI:R/"
+            "E:H/RL:O/RC:R/CR:H/IR:X/AR:X/MAC:H/MPR:X/MUI:X/MC:L/MA:X"
+        )
+        self.assertEqual(
+            "E:H/RL:O/RC:R",
+            CVSS3(v).temporal_vector(),
+        )
+
+        v = (
+            "CVSS:3.0/S:C/C:H/I:H/A:N/AV:P/AC:H/PR:H/UI:R/"
+            "CR:H/IR:X/AR:X/MAC:H/MPR:X/MUI:X/MC:L/MA:X"
+        )
+        self.assertEqual(
+            "E:X/RL:X/RC:X",
+            CVSS3(v).temporal_vector(),
+        )
+
+        v = (
+            "CVSS:3.0/S:C/C:H/I:H/A:N/AV:P/AC:H/PR:H/UI:R/"
+            "RL:O/RC:R/CR:H/IR:X/AR:X/MAC:H/MPR:X/MUI:X/MC:L/MA:X"
+        )
+        self.assertEqual(
+            "E:X/RL:O/RC:R",
+            CVSS3(v).temporal_vector(),
+        )
+
+        v = (
+            "CVSS:3.0/S:C/C:H/I:H/A:N/AV:P/AC:H/PR:H/UI:R/"
+            "E:H/RC:R/CR:H/IR:X/AR:X/MAC:H/MPR:X/MUI:X/MC:L/MA:X"
+        )
+        self.assertEqual(
+            "E:H/RL:X/RC:R",
+            CVSS3(v).temporal_vector(),
+        )
+
+        v = (
+            "CVSS:3.0/S:C/C:H/I:H/A:N/AV:P/AC:H/PR:H/UI:R/"
+            "E:H/RL:O/CR:H/IR:X/AR:X/MAC:H/MPR:X/MUI:X/MC:L/MA:X"
+        )
+        self.assertEqual(
+            "E:H/RL:O/RC:X",
+            CVSS3(v).temporal_vector(),
+        )
+
+    def test_environmental_vector(self):
+        """
+        Test for retrieving only the Environmental CVSS Vector.
+        """
+        v = (
+            "CVSS:3.0/S:C/C:H/I:H/A:N/AV:P/AC:H/PR:H/UI:R/"
+            "E:H/RL:O/RC:R/CR:H/IR:X/AR:X/MAC:H/MPR:X/MUI:X/MC:L/MA:X"
+        )
+        self.assertEqual(
+            "CR:H/IR:X/AR:X/MAV:P/MAC:H/MPR:H/MUI:R/MS:C/MC:L/MI:H/MA:N",
+            CVSS3(v).environmental_vector(),
+        )
+
+        v = "CVSS:3.0/S:C/C:H/I:H/A:N/AV:P/AC:H/PR:H/UI:R/E:H/RL:O/RC:R"
+        self.assertEqual(
+            "CR:X/IR:X/AR:X/MAV:P/MAC:H/MPR:H/MUI:R/MS:C/MC:H/MI:H/MA:N",
+            CVSS3(v).environmental_vector(),
+        )
+
+        v = (
+            "CVSS:3.0/S:C/C:H/I:H/A:N/AV:P/AC:H/PR:H/UI:R/"
+            "E:H/RL:O/RC:R/MAV:N/MAC:L/MPR:N/MUI:R/MS:C/MC:L/MI:N/MA:H/CR:M/IR:L/AR:M"
+        )
+        self.assertEqual(
+            "CR:M/IR:L/AR:M/MAV:N/MAC:L/MPR:N/MUI:R/MS:C/MC:L/MI:N/MA:H",
+            CVSS3(v).environmental_vector(),
+        )
+
     def test_parse_from_text_cvss3(self):
         i = "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H"
         e = [CVSS3(i)]


### PR DESCRIPTION
This Pull Request introduces an enhanced feature that allows users to fetch isolated Temporal and Environmental CVSS vectors specifically for both CVSS version 2.0 and the 3.X series. 

The isolated vectors provide a more granular view of vulnerabilities by separating the base metrics from the Temporal and Environmental metrics.

Additionally, the unit tests have been modified to ensure that these changes are properly implemented and validated.