### PR TITLE
Fix CVSS4 clean vector field ordering - Threat and Environmental metrics generate invalid vectors

### DIFF
--- a/cvss/cvss4.py
+++ b/cvss/cvss4.py
@@ -607,7 +607,7 @@ class CVSS4(object):
 
     def clean_vector(self, output_prefix=True):
         """
-        Returns vector without optional metrics marked as X and in preferred order.
+        Returns vector without optional metrics marked as X and in the required order.
 
         Args:
             output_prefix (bool): defines if CVSS vector should be printed with prefix
@@ -615,6 +615,10 @@ class CVSS4(object):
         Returns:
             (str): cleaned CVSS4 with metrics in correct order
         """
+        # The metrics from METRICS_ABBREVIATIONS are ordered in accordance with the
+        # CVSS4 specification. Vectors that are not ordered are considered invalid
+        # an may be rejected.
+        # https://www.first.org/cvss/v4-0/specification-document#Vector-String
         vector = []
         for metric in METRICS_ABBREVIATIONS:
             if metric in self.original_metrics:

--- a/tests/test_cvss4.py
+++ b/tests/test_cvss4.py
@@ -248,6 +248,16 @@ class TestCVSS4(unittest.TestCase):
         v = "ABC|AV:N/AC:L/AT:N/PR:L/UI:N/VC:H/VI:L/VA:N/SC:H/SI:N/SA:L"
         self.assertRaises(CVSS4RHMalformedError, CVSS4.from_rh_vector, v)
 
+    def test_clean_vector_field_order(self):
+        # This vector is sorted following the specification requirement and
+        # should match the clean_vector.
+        v = (
+            "CVSS:4.0/AV:P/AC:H/AT:P/PR:H/UI:A/VC:N/VI:N/VA:N/SC:N/SI:N/SA:N/"
+            "E:U/CR:L/IR:L/AR:L/MAV:P/MAC:H/MAT:P/MPR:H/MUI:A/MVC:N/MVI:N/"
+            "MVA:N/MSC:N/MSI:N/MSA:N/S:P/AU:Y/R:I/V:C/RE:H/U:Red"
+        )
+        self.assertEqual(CVSS4(v).clean_vector(), v, "Invalid CVSS4 metric field order")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fix CVSS4 vectors generated by this module to follow the ordering from the specifications[1]. Before this change all vectors with Threat and Environmental metrics would be invalid and rejected by other CVSS tools[2].

[1] https://www.first.org/cvss/v4-0/specification-document#Vector-String
[2] https://redhatproductsecurity.github.io/cvss-v4-calculator/

This is related to https://github.com/RedHatProductSecurity/cvss/issues/66 but does not add input validation because the doc strings explicitly mention that fields may be out of order. I've updated the ordering of the other metrics lists in sync with the specification too.