### PR TITLE
fix: add CVSS4 support to parse_cvss_from_text

### DIFF
--- a/cvss/parser.py
+++ b/cvss/parser.py
@@ -18,10 +18,11 @@ def parse_cvss_from_text(text):
     Returns:
         A list of CVSS objects.
     """
-    # Looks for substrings which resemble CVSS2, CVSS3 or CVSS4 vectors.
-    # CVSS3 vector starts with 'CVSS:3.x/' prefix - matched by non-capturing group.
-    # Minimum vector length is 26.
-    matches = re.compile(r"(?:CVSS:[2-4]\.\d/)?[A-Za-z:/]{26,}").findall(text)
+    # Looks for substrings that resemble CVSS2, CVSS3, or CVSS4 vectors.
+    # CVSS3 and CVSS4 vectors start with a 'CVSS:x.x/' prefix and are matched by the optional non-capturing group.
+    # CVSS2 vectors do not include a prefix and are matched by raw vector pattern only.
+    # Minimum total match length is 26 characters to reduce false positives.
+    matches = re.compile(r"(?:CVSS:[3-4]\.\d/)?[A-Za-z:/]{26,}").findall(text)
 
     cvsss = set()
     for match in matches:

--- a/cvss/parser.py
+++ b/cvss/parser.py
@@ -2,12 +2,13 @@ import re
 
 from .cvss2 import CVSS2
 from .cvss3 import CVSS3
+from .cvss4 import CVSS4
 from .exceptions import CVSSError
 
 
 def parse_cvss_from_text(text):
     """
-    Parses CVSS2 and CVSS3 vectors from arbitrary text and returns a list of CVSS objects.
+    Parses CVSS2, CVSS3, and CVSS4 vectors from arbitrary text and returns a list of CVSS objects.
 
     Parses text for substrings that look similar to CVSS vector
     and feeds these matches to CVSS constructor.
@@ -17,15 +18,17 @@ def parse_cvss_from_text(text):
     Returns:
         A list of CVSS objects.
     """
-    # Looks for substrings which resemble CVSS2 or CVSS3 vectors.
+    # Looks for substrings which resemble CVSS2, CVSS3 or CVSS4 vectors.
     # CVSS3 vector starts with 'CVSS:3.x/' prefix - matched by non-capturing group.
     # Minimum vector length is 26.
-    matches = re.compile(r"(?:CVSS:3\.\d/)?[A-Za-z:/]{26,}").findall(text)
+    matches = re.compile(r"(?:CVSS:[2-4]\.\d/)?[A-Za-z:/]{26,}").findall(text)
 
     cvsss = set()
     for match in matches:
         try:
-            if match.startswith("CVSS:3."):
+            if match.startswith("CVSS:4."):
+                cvss = CVSS4(match)
+            elif match.startswith("CVSS:3."):
                 cvss = CVSS3(match)
             else:
                 cvss = CVSS2(match)


### PR DESCRIPTION
Added support for parsing CVSS4 vectors in the parse_cvss_from_text function.
Updated the regex to detect CVSS:2.x, CVSS:3.x, and CVSS:4.x vectors and added handling using the CVSS4 class.
Existing CVSS2 and CVSS3 logic remains unchanged.